### PR TITLE
test: Implement comprehensive integration test for dashboard data rendering (Fixes #40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Feature]: Core SRS risk analysis model integration with multi-factor algorithm (#30)
 - [Feature]: Dashboard endpoint logic to read and parse results.json files with live analysis fallback (#38)
 - [Feature]: Batch analysis script for results.json generation with comprehensive unit tests (#31)
+- [Feature]: Dashboard template dynamically renders risk scores with Jinja2 from results.json data (#39)
+- [Testing]: Comprehensive integration test for dashboard data rendering with mock results.json validation (#40)
 
 ### Changed
 


### PR DESCRIPTION
## 🔗 Linked Issues & Stories
- **GitHub Issue:** Fixes #40
- **Shortcut Story:** Partner views risk scores on the dashboard
- **Story Status:** COMPLETE - This issue completion completes the entire story

## 📋 Summary of Changes
- Fixed previously skipped `test_dashboard_with_valid_auth_succeeds` test by implementing proper auth service mocking using monkeypatch
- Added comprehensive integration test `test_dashboard_data_rendering_with_mock_results` that validates end-to-end data flow from authentication → data loading → template rendering → HTML output
- Added test `test_dashboard_data_rendering_different_risk_levels` that validates all risk level categorizations (low/medium/high) with different cage IDs and risk scores
- Added test `test_dashboard_data_rendering_without_results_file` for graceful handling of missing data scenarios
- Uses proper monkeypatch techniques to mock AuthService with test tokens and control data sources during testing
- Creates temporary results.json files with exact format expected by the system for realistic integration testing

## 🧪 Testing Instructions
### Manual Testing Steps:
1. Run the full test suite: `pixi run test`
2. Verify all 156 tests pass (154 passed + 2 skipped)
3. Check specifically that new integration tests validate:
   - Dashboard authentication flow works correctly
   - Dashboard renders specific data from mock results.json files
   - Risk level categorization is accurate (low: <0.3, medium: 0.3-0.7, high: >0.7)
   - Error handling when no results.json file exists

### Verification Checklist:
- [x] All tests pass with clean linting
- [x] Integration tests validate complete authentication → data → rendering flow
- [x] Mock data scenarios test all risk level categorizations
- [x] Error scenarios are handled gracefully
- [x] HTML output contains expected data from test scenarios

## 🔍 How to Verify Issue Resolution
- The integration test `test_dashboard_data_rendering_with_mock_results` directly addresses the issue requirement by creating a mock `results.json` file, calling the dashboard endpoint with valid authentication, and asserting that the returned HTML contains specific data from the mock file
- Tests verify that cage ID "CAGE-TEST-42", risk score "0.850", risk level "high", and status "Analysis completed successfully" appear in the rendered HTML
- The test ensures placeholder content is NOT present when real data is available, confirming the dashboard correctly displays actual risk assessment data

## 📸 Screenshots/Visual Evidence
N/A - Integration test validates HTML content programmatically

## ⚠️ Breaking Changes
None

## 📝 Additional Notes
This pull request completes the final task in the "Partner views risk scores on the dashboard" story. Issues #38 (backend logic) and #39 (frontend template) were already completed and closed. With this integration test implementation, the entire story is now complete and ready for release.