### PR TITLE
docs: Create partner guide for uploading data via API (Fixes #26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Feature]: Dashboard template dynamically renders risk scores with Jinja2 from results.json data (#39)
 - [Testing]: Comprehensive integration test for dashboard data rendering with mock results.json validation (#40)
 - [Documentation]: Critical alert email template with complete usage instructions and example (#42)
+- [Documentation]: Partner API guide for uploading data via API with authentication and troubleshooting (#26)
 
 ### Changed
 

--- a/docs/partner-api-guide.md
+++ b/docs/partner-api-guide.md
@@ -1,0 +1,233 @@
+# Project Thalassa - Partner API Guide
+
+Welcome to Project Thalassa's bioinformatics analysis platform. This guide will help you upload your sequence data files for SRS risk assessment analysis.
+
+## Quick Start
+
+To upload your data files, you'll need:
+1. Your authentication token (provided separately)
+2. A properly formatted `.fastq` file
+3. A tool to make HTTP requests (like `cURL` or similar)
+
+## Authentication
+
+All API requests require a Bearer token in the Authorization header. Replace `YOUR_TOKEN_HERE` in the examples below with your actual authentication token.
+
+```
+Authorization: Bearer YOUR_TOKEN_HERE
+```
+
+## File Upload
+
+### Endpoint Information
+
+- **URL:** `https://your-server-domain.com/api/v1/upload`
+- **Method:** POST
+- **Content-Type:** multipart/form-data
+- **Authentication:** Bearer token required
+
+### File Naming Convention
+
+**CRITICAL:** Your files must follow this exact naming pattern:
+
+```
+PartnerID_CageID_YYYY-MM-DD_SampleID.fastq
+```
+
+**Components:**
+- `PartnerID`: Your organization identifier (e.g., "Mowi", "SalMar")
+- `CageID`: Unique cage identifier (e.g., "CAGE-04B", "SITE-A-01")
+- `YYYY-MM-DD`: Sample collection date in ISO format
+- `SampleID`: Sample identifier within the cage (e.g., "S01", "Sample-001")
+
+**Valid Examples:**
+- `Mowi_CAGE-04B_2025-08-15_S01.fastq`
+- `SalMar_SITE-A-01_2025-12-03_Sample-001.fastq`
+- `AquaGen_FARM-12_2025-11-20_SEQ-001.fastq`
+
+### Upload Using cURL
+
+Here's how to upload a file using cURL:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer YOUR_TOKEN_HERE" \
+  -F "file=@/path/to/your/Mowi_CAGE-04B_2025-08-15_S01.fastq" \
+  https://your-server-domain.com/api/v1/upload
+```
+
+**Replace:**
+- `YOUR_TOKEN_HERE` with your actual Bearer token
+- `/path/to/your/` with the actual path to your file
+- `Mowi_CAGE-04B_2025-08-15_S01.fastq` with your actual filename
+- `your-server-domain.com` with the actual server URL
+
+### Successful Upload Response
+
+When your file uploads successfully, you'll receive a response like this:
+
+```json
+{
+  "message": "File uploaded successfully",
+  "filename": "Mowi_CAGE-04B_2025-08-15_S01.fastq",
+  "file_path": "/uploads/Mowi_CAGE-04B_2025-08-15_S01.fastq",
+  "metadata": {
+    "partner_id": "Mowi",
+    "cage_id": "CAGE-04B",
+    "sample_date": "2025-08-15",
+    "sample_id": "S01",
+    "original_filename": "Mowi_CAGE-04B_2025-08-15_S01.fastq",
+    "file_size": 1048576
+  }
+}
+```
+
+## Alternative Upload Methods
+
+### Using PowerShell (Windows)
+
+```powershell
+$headers = @{
+    "Authorization" = "Bearer YOUR_TOKEN_HERE"
+}
+
+$form = @{
+    "file" = Get-Item "C:\path\to\your\Mowi_CAGE-04B_2025-08-15_S01.fastq"
+}
+
+Invoke-RestMethod -Uri "https://your-server-domain.com/api/v1/upload" -Method Post -Headers $headers -Form $form
+```
+
+### Using Python requests
+
+```python
+import requests
+
+url = "https://your-server-domain.com/api/v1/upload"
+headers = {
+    "Authorization": "Bearer YOUR_TOKEN_HERE"
+}
+
+with open("Mowi_CAGE-04B_2025-08-15_S01.fastq", "rb") as file:
+    files = {"file": file}
+    response = requests.post(url, headers=headers, files=files)
+    print(response.json())
+```
+
+## Error Responses
+
+### Common Error Codes
+
+| Status Code | Description | Solution |
+|-------------|-------------|----------|
+| 400 | Bad Request - Invalid filename format | Check your filename follows the required pattern |
+| 401 | Unauthorized - Invalid or missing token | Verify your Bearer token is correct |
+| 409 | Conflict - File already exists | File with this name was already uploaded |
+| 422 | Validation Error - No file provided | Ensure you're including the file in your request |
+
+### Authentication Errors
+
+**Missing Authorization Header:**
+```json
+{
+  "detail": "Authorization header is required"
+}
+```
+**Solution:** Add the Authorization header with your Bearer token.
+
+**Invalid Bearer Token:**
+```json
+{
+  "detail": "Invalid bearer token"
+}
+```
+**Solution:** Verify your token is correct and active.
+
+### File Validation Errors
+
+**Invalid Filename Format:**
+```json
+{
+  "detail": "Invalid filename format. Expected: PartnerID_CageID_YYYY-MM-DD_SampleID.fastq"
+}
+```
+**Solution:** Rename your file to follow the exact naming convention.
+
+**File Too Large:**
+```json
+{
+  "detail": "File size exceeds maximum limit of 100MB"
+}
+```
+**Solution:** Compress your file or contact support for large file handling.
+
+## File Management
+
+### Check Uploaded Files
+
+You can view all your uploaded files:
+
+```bash
+curl -X GET \
+  -H "Authorization: Bearer YOUR_TOKEN_HERE" \
+  https://your-server-domain.com/api/v1/upload/files
+```
+
+**Response:**
+```json
+{
+  "files": [
+    {
+      "filename": "Mowi_CAGE-04B_2025-08-15_S01.fastq",
+      "partner_id": "Mowi",
+      "cage_id": "CAGE-04B",
+      "sample_date": "2025-08-15",
+      "sample_id": "S01",
+      "file_size": 1048576,
+      "upload_time": 1692097200.0
+    }
+  ],
+  "total_count": 1
+}
+```
+
+## Best Practices
+
+### File Preparation
+- **Validate your files** before uploading to ensure they're properly formatted FASTQ files
+- **Check file size** - files larger than 100MB may require special handling
+- **Use consistent naming** - maintain the same PartnerID across all your uploads
+
+### Upload Process
+- **Upload during business hours** when technical support is available
+- **Verify successful upload** by checking the response message
+- **Keep upload confirmations** for your records
+
+### Troubleshooting
+- **Connection issues:** Verify the server URL and your internet connection
+- **Authentication issues:** Confirm your Bearer token is active and correctly formatted
+- **File issues:** Ensure your FASTQ files are not corrupted and follow naming conventions
+
+## Support
+
+If you encounter issues not covered in this guide:
+
+1. **Check the error message** in the API response for specific guidance
+2. **Verify your file format** and naming convention
+3. **Test with a smaller file** if experiencing upload issues
+4. **Contact technical support** with the specific error message you received
+
+## Analysis Process
+
+After successful upload:
+1. Your files will be queued for bioinformatics analysis
+2. The SRS risk assessment model will process your sequence data
+3. Results will be available on the dashboard (separate access instructions provided)
+4. Critical risk scores will trigger manual alerts from our analysis team
+
+## Security Notes
+
+- **Keep your Bearer token secure** - do not share it or include it in version control
+- **Use HTTPS** for all API communications
+- **Files are processed securely** according to data protection standards
+- **Contact support immediately** if you suspect token compromise


### PR DESCRIPTION
## 🔗 Linked Issues & Stories
- **GitHub Issue:** Fixes #26
- **Shortcut Story:** Partner provides sequence data via a shared folder
- **Story Status:** INCOMPLETE - Issue #27 (integration test) remains open

## 📋 Summary of Changes
- Created comprehensive partner API guide (`docs/partner-api-guide.md`) with detailed upload instructions
- Included endpoint URL, authentication requirements, and Bearer token examples
- Added mandatory file naming convention: `PartnerID_CageID_YYYY-MM-DD_SampleID.fastq`
- Provided practical cURL examples and alternative methods (PowerShell, Python)
- Added comprehensive troubleshooting, error handling, and security sections
- Updated CHANGELOG.md with documentation entry
- Ensured partner-friendly language for self-service capability

## 🧪 Testing Instructions
### Manual Testing Steps:
1. Review the partner API guide at `docs/partner-api-guide.md`
2. Verify all sections are complete and clear for partners
3. Check that file naming convention is properly documented
4. Ensure API endpoint and authentication examples are accurate
5. Test that the guide provides sufficient self-service information

### Verification Checklist:
- [ ] Partner guide includes correct API endpoint URL
- [ ] Bearer token authentication is properly documented
- [ ] File naming convention is clearly specified with examples
- [ ] Multiple upload methods (cURL, PowerShell, Python) are provided
- [ ] Troubleshooting and error handling sections are comprehensive
- [ ] Security best practices are documented
- [ ] Language is partner-friendly and non-technical where appropriate

## 🔍 How to Verify Issue Resolution
- Confirm that the guide addresses all requirements from issue #26
- Verify that partners can use the guide to upload files independently
- Check that the guide includes all mandatory elements: endpoint, auth, naming convention
- Ensure the documentation is complete for production partner usage

## 📸 Screenshots/Visual Evidence
Documentation file - no visual evidence required for text-based guide.

## ⚠️ Breaking Changes
None - This is purely additive documentation.

## 📝 Additional Notes
This documentation completes the partner-facing requirements for the upload API feature. The guide is designed for self-service use by partners with minimal technical expertise. The story will be completed once issue #27 (integration tests) is also resolved.